### PR TITLE
Deprecare `original_agent`

### DIFF
--- a/core_network/src/main/java/com/inensus/core_network/model/Payment.kt
+++ b/core_network/src/main/java/com/inensus/core_network/model/Payment.kt
@@ -15,7 +15,7 @@ data class Payment(
     @SerializedName("amount") val amount: BigDecimal,
     @SerializedName("created_at") val createdAt: Date,
     @SerializedName("transaction") val transaction: Transaction?,
-    @SerializedName("original_agent") val originalAgent: OriginalAgent?,
+    @SerializedName("original_transaction") val originalTransaction: OriginalTransaction?,
     @SerializedName("device") val device: PaymentDevice?,
     @SerializedName("token") val token: Token?,
 ) : Parcelable
@@ -27,7 +27,7 @@ data class Transaction(
 ) : Parcelable
 
 @Parcelize
-data class OriginalAgent(
+data class OriginalTransaction(
     @SerializedName("status") val status: Int,
 ) : Parcelable
 

--- a/feature_payment/src/main/java/com/inensus/feature_payment/payment_list/view/PaymentListAdapter.kt
+++ b/feature_payment/src/main/java/com/inensus/feature_payment/payment_list/view/PaymentListAdapter.kt
@@ -45,7 +45,7 @@ class PaymentListAdapter : RecyclerView.Adapter<PaymentListAdapter.ViewHolder>()
             with(binding) {
                 val context = root.context
                 statusImage.setImageDrawable(
-                    when (payment.originalAgent?.status) {
+                    when (payment.originalTransaction?.status) {
                         1 -> ContextCompat.getDrawable(context, R.drawable.ic_success)
                         0 -> ContextCompat.getDrawable(context, R.drawable.ic_pending)
                         -1 -> ContextCompat.getDrawable(context, R.drawable.ic_status_error)


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Parity change to: https://github.com/EnAccess/micropowermanager/pull/612

Before we would have three fields at transaction level

- `original_agent`
- `original_cash`
- `original_wave_money`

With only the correct one being non-null. https://github.com/EnAccess/micropowermanager/pull/612 introduced proper polymorphism via `original_transaction`.

Adapting the Agent app, so we can clean up the backend.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
